### PR TITLE
Add Helm chart for workload deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # k8s-deploy-refactor
+
+Helm-ified version of the original Kustomize deployment templates. The `charts/workload` chart
+contains templated manifests for the workload Deployment/StatefulSet, Service, Istio resources,
+ConfigMaps, Secrets, HPA and optional persistent volumes.
+
+## Quick start
+
+```bash
+helm template los-clos charts/workload -f charts/workload/values-uat.yaml --set image.tag=1.0.0
+```
+
+Use additional values files or `--set` flags to adapt the chart for other environments.

--- a/charts/workload/Chart.yaml
+++ b/charts/workload/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: workload
+description: Helm chart derived from the example-workload Kustomize manifests.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/workload/README.md
+++ b/charts/workload/README.md
@@ -1,0 +1,29 @@
+# Workload Helm chart
+
+This chart re-packages the manifests that previously lived under `example-workload` into a
+configurable Helm chart. It is designed to let Jenkins or other automation pass parameters instead
+of replacing `<PLACEHOLDER>` tokens with `sed`.
+
+## Structure
+
+* `Chart.yaml` – chart metadata.
+* `values.yaml` – default configuration for the workload, service, HPA, Istio objects and the static
+  persistent volume example.
+* `values-uat.yaml` – opinionated overlay that mirrors the former `uat` Kustomize overlays.
+* `templates/` – Kubernetes manifests rendered from the values above.
+
+## Usage
+
+```bash
+# Render manifests locally
+helm template los-clos charts/workload -f charts/workload/values-uat.yaml \
+  --set image.tag=1.2.3
+
+# Install into a namespace
+helm upgrade --install los-clos charts/workload -n los --create-namespace \
+  -f charts/workload/values-uat.yaml \
+  --set image.tag=1.2.3
+```
+
+Override any value either through additional `-f` files or `--set/--set-string`. Secrets should be
+supplied at deploy time using `--set-string` or `--set-file`; the sample values use placeholders only.

--- a/charts/workload/templates/_helpers.tpl
+++ b/charts/workload/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{- define "workload.name" -}}
+{{- if .Values.nameOverride -}}
+{{- .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .Chart.Name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "workload.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "workload.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "workload.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" -}}
+{{- end -}}
+
+{{- define "workload.labels" -}}
+helm.sh/chart: {{ include "workload.chart" . }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.workload.component }}
+app.kubernetes.io/component: {{ .Values.workload.component | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "workload.appLabel" -}}
+{{- default (include "workload.fullname" .) .Values.workload.appLabel -}}
+{{- end -}}
+
+{{- define "workload.selectorLabels" -}}
+app: {{ include "workload.appLabel" . }}
+{{- with .Values.workload.version }}
+version: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "workload.matchLabels" -}}
+{{ include "workload.selectorLabels" . }}
+{{- end -}}
+
+{{- define "workload.configMapName" -}}
+{{- default (printf "%s-config" (include "workload.fullname" .)) .Values.configMap.name -}}
+{{- end -}}
+
+{{- define "workload.secretName" -}}
+{{- default (printf "%s-secret" (include "workload.fullname" .)) .Values.secrets.name -}}
+{{- end -}}
+
+{{- define "workload.serviceName" -}}
+{{- default (include "workload.fullname" .) .Values.service.name -}}
+{{- end -}}
+
+{{- define "workload.workloadKind" -}}
+{{- $kind := default "Deployment" .Values.workload.kind -}}
+{{- if eq (lower $kind) "statefulset" -}}StatefulSet{{- else -}}Deployment{{- end -}}
+{{- end -}}

--- a/charts/workload/templates/configmap.yaml
+++ b/charts/workload/templates/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.configMap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "workload.configMapName" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+data:
+  {{- range $key, $value := .Values.configMap.data }}
+  {{ $key }}: |
+{{ tpl $value $ | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/workload/templates/deployment.yaml
+++ b/charts/workload/templates/deployment.yaml
@@ -1,0 +1,125 @@
+{{- if eq (include "workload.workloadKind" .) "Deployment" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workload.fullname" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+    {{- with .Values.workload.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.workload.replicas }}
+  revisionHistoryLimit: {{ .Values.workload.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "workload.matchLabels" . | nindent 6 }}
+  {{- with .Values.workload.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "workload.matchLabels" . | nindent 8 }}
+      {{- with .Values.workload.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ default (include "workload.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.workload.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.workload.terminationGracePeriodSeconds }}
+      {{- end }}
+      containers:
+        - name: {{ include "workload.appLabel" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.workload.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workload.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workload.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.workload.envFrom (and .Values.secrets.enabled .Values.secrets.autoMount) }}
+          envFrom:
+            {{- with .Values.workload.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if and .Values.secrets.enabled .Values.secrets.autoMount }}
+            - secretRef:
+                name: {{ include "workload.secretName" . }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.workload.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $configMapEnabled := and .Values.configMap.enabled .Values.configMap.data }}
+          {{- if or $configMapEnabled .Values.workload.volumeMounts .Values.workload.extraVolumeMounts }}
+          volumeMounts:
+            {{- if $configMapEnabled }}
+            - name: config
+              mountPath: {{ default "/opt/config" .Values.configMap.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.workload.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.workload.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.workload.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workload.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- $configMapEnabled := and .Values.configMap.enabled .Values.configMap.data }}
+      {{- if or $configMapEnabled .Values.workload.extraVolumes }}
+      volumes:
+        {{- if $configMapEnabled }}
+        - name: config
+          configMap:
+            name: {{ include "workload.configMapName" . }}
+        {{- end }}
+        {{- with .Values.workload.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.workload.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/workload/templates/destinationrule.yaml
+++ b/charts/workload/templates/destinationrule.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.istio.enabled .Values.istio.subsets }}
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: {{ include "workload.serviceName" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+spec:
+  host: {{ default (include "workload.serviceName" .) .Values.istio.serviceHost }}
+  subsets:
+{{ toYaml .Values.istio.subsets | indent 4 }}
+{{- end }}

--- a/charts/workload/templates/hpa.yaml
+++ b/charts/workload/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: {{ default "autoscaling/v2" .Values.hpa.apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "workload.fullname" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+  {{- with .Values.hpa.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ include "workload.workloadKind" . }}
+    name: {{ include "workload.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  {{- if .Values.hpa.metrics }}
+  metrics:
+{{ tpl (toYaml .Values.hpa.metrics) . | indent 4 }}
+  {{- end }}
+  {{- with .Values.hpa.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/workload/templates/pdb.yaml
+++ b/charts/workload/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "workload.fullname" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- else if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "workload.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/workload/templates/persistence.yaml
+++ b/charts/workload/templates/persistence.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.persistence.volumeName }}
+  {{- with .Values.persistence.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  persistentVolumeReclaimPolicy: {{ default "Delete" .Values.persistence.persistentVolume.reclaimPolicy }}
+  capacity:
+    storage: {{ .Values.persistence.persistentVolume.capacity }}
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.persistentVolume.hostPath }}
+  hostPath:
+    path: {{ . | quote }}
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.persistence.claimName }}
+spec:
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.persistentVolumeClaim.requests.storage }}
+{{- end }}

--- a/charts/workload/templates/secret.yaml
+++ b/charts/workload/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.secrets.enabled .Values.secrets.stringData }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "workload.secretName" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+{{- with .Values.secrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+type: {{ default "Opaque" .Values.secrets.type }}
+stringData:
+  {{- range $key, $value := .Values.secrets.stringData }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/workload/templates/service.yaml
+++ b/charts/workload/templates/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workload.serviceName" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ default "ClusterIP" .Values.service.type }}
+  selector:
+    {{- include "workload.selectorLabels" . | nindent 4 }}
+  {{- with .Values.service.sessionAffinity }}
+  sessionAffinity: {{ . }}
+  {{- end }}
+  ports:
+    {{- range .Values.service.ports }}
+    - name: {{ default "http" .name }}
+      port: {{ required "service.ports[].port is required" .port }}
+      targetPort: {{ default .port .targetPort }}
+      protocol: {{ default "TCP" .protocol }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+    {{- end }}
+{{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ . }}
+{{- end }}
+{{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+{{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/charts/workload/templates/serviceaccount.yaml
+++ b/charts/workload/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default (include "workload.fullname" .) .Values.serviceAccount.name }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/workload/templates/statefulset.yaml
+++ b/charts/workload/templates/statefulset.yaml
@@ -1,0 +1,121 @@
+{{- if eq (include "workload.workloadKind" .) "StatefulSet" }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "workload.fullname" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+    {{- with .Values.workload.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  serviceName: {{ include "workload.serviceName" . }}
+  replicas: {{ .Values.workload.replicas }}
+  selector:
+    matchLabels:
+      {{- include "workload.matchLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "workload.matchLabels" . | nindent 8 }}
+      {{- with .Values.workload.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ default (include "workload.fullname" .) .Values.serviceAccount.name }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.workload.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.workload.terminationGracePeriodSeconds }}
+      {{- end }}
+      containers:
+        - name: {{ include "workload.appLabel" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.workload.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workload.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workload.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.workload.envFrom (and .Values.secrets.enabled .Values.secrets.autoMount) }}
+          envFrom:
+            {{- with .Values.workload.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if and .Values.secrets.enabled .Values.secrets.autoMount }}
+            - secretRef:
+                name: {{ include "workload.secretName" . }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.workload.ports }}
+          ports:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $configMapEnabled := and .Values.configMap.enabled .Values.configMap.data }}
+          {{- if or $configMapEnabled .Values.workload.volumeMounts .Values.workload.extraVolumeMounts }}
+          volumeMounts:
+            {{- if $configMapEnabled }}
+            - name: config
+              mountPath: {{ default "/opt/config" .Values.configMap.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.workload.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.workload.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.workload.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.workload.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- $configMapEnabled := and .Values.configMap.enabled .Values.configMap.data }}
+      {{- if or $configMapEnabled .Values.workload.extraVolumes }}
+      volumes:
+        {{- if $configMapEnabled }}
+        - name: config
+          configMap:
+            name: {{ include "workload.configMapName" . }}
+        {{- end }}
+        {{- with .Values.workload.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.workload.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workload.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/workload/templates/virtualservice.yaml
+++ b/charts/workload/templates/virtualservice.yaml
@@ -1,0 +1,47 @@
+{{- if and .Values.istio.enabled (or .Values.istio.hosts .Values.istio.routes) }}
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ include "workload.serviceName" . }}
+  labels:
+    {{- include "workload.labels" . | nindent 4 }}
+    app: {{ include "workload.appLabel" . }}
+spec:
+  {{- if .Values.istio.hosts }}
+  hosts:
+    {{- toYaml .Values.istio.hosts | nindent 4 }}
+  {{- else }}
+  hosts:
+    - {{ include "workload.serviceName" . }}
+  {{- end }}
+  {{- with .Values.istio.gateways }}
+  gateways:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  http:
+  {{- if .Values.istio.routes }}
+{{ tpl (toYaml .Values.istio.routes) . | indent 4 }}
+  {{- else }}
+    - match:
+        - uri:
+            prefix: {{ default "/" .Values.istio.contextPrefix }}
+          headers:
+            version:
+              exact: pilot
+      route:
+        - destination:
+            host: {{ include "workload.serviceName" . }}
+            subset: pilot
+            port:
+              number: {{ .Values.istio.port }}
+    - match:
+        - uri:
+            prefix: {{ default "/" .Values.istio.contextPrefix }}
+      route:
+        - destination:
+            host: {{ include "workload.serviceName" . }}
+            subset: live
+            port:
+              number: {{ .Values.istio.port }}
+  {{- end }}
+{{- end }}

--- a/charts/workload/values-uat.yaml
+++ b/charts/workload/values-uat.yaml
@@ -1,0 +1,145 @@
+image:
+  repository: nexus.example.com/los-clos-api
+  tag: "1.0.0"
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: nexus-repo-secret
+
+workload:
+  kind: Deployment
+  appLabel: los-clos-api
+  version: live
+  replicas: 1
+  terminationGracePeriodSeconds: 30
+  env:
+    - name: TZ
+      value: Asia/Ho_Chi_Minh
+    - name: SPRING_PROFILES_INCLUDE
+      value: fwbase
+  resources:
+    requests:
+      cpu: "2"
+      memory: 2Gi
+    limits:
+      cpu: "4"
+      memory: 4Gi
+  nodeSelector:
+    app: sbapi
+  tolerations:
+    - effect: NoSchedule
+      key: app
+      operator: Equal
+      value: non-system
+
+service:
+  type: NodePort
+  ports:
+    - name: http-sbapi
+      port: 8081
+      targetPort: 8081
+
+configMap:
+  enabled: true
+  mountPath: /opt/config
+  data:
+    application.yml: |-
+      server:
+        port: 8081
+        servlet:
+          contextPath: /LOS_CLOS_API
+      spring:
+        profiles:
+          active: uat
+        datasource:
+          url: ${SPRING_DATASOURCE_URL}
+          username: ${SPRING_DATASOURCE_USERNAME}
+          password: ${SPRING_DATASOURCE_PASSWORD}
+      logging:
+        level:
+          com.seabank.fe: debug
+          org.apache.kafka: ERROR
+
+secrets:
+  enabled: true
+  autoMount: true
+  stringData:
+    SPRING_DATASOURCE_URL: jdbc:postgresql://example:5432/SEABAPI?currentSchema=los_clos_api
+    SPRING_DATASOURCE_USERNAME: los_clos_api
+    SPRING_DATASOURCE_PASSWORD: changeme
+
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageValue
+          averageValue: "80"
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: External
+      external:
+        metric:
+          name: istio.io|service|server|request_count
+          selector:
+            matchLabels:
+              resource.type: k8s_container
+              metric.labels.destination_service_name: '{{ include "workload.appLabel" . }}'
+        target:
+          type: AverageValue
+          averageValue: "10"
+  behavior:
+    scaleDown:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 300
+    scaleUp:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 240
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+istio:
+  enabled: true
+  serviceHost: '{{ include "workload.serviceName" . }}'
+  hosts:
+    - uat-asmbpmapi.example.com
+  gateways:
+    - asm-gateway/bpm-ingress
+  contextPrefix: /LOS_CLOS_API
+  port: 8081
+  routes:
+    - match:
+        - uri:
+            prefix: '{{ .Values.istio.contextPrefix }}'
+          headers:
+            version:
+              exact: pilot
+      route:
+        - destination:
+            host: '{{ include "workload.serviceName" . }}'
+            subset: pilot
+            port:
+              number: {{ .Values.istio.port }}
+    - match:
+        - uri:
+            prefix: '{{ .Values.istio.contextPrefix }}'
+      route:
+        - destination:
+            host: '{{ include "workload.serviceName" . }}'
+            subset: live
+            port:
+              number: {{ .Values.istio.port }}

--- a/charts/workload/values.yaml
+++ b/charts/workload/values.yaml
@@ -1,0 +1,186 @@
+image:
+  repository: example.com/workload
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+workload:
+  kind: Deployment
+  appLabel: ""
+  version: live
+  component: ""
+  replicas: 1
+  revisionHistoryLimit: 10
+  strategy: {}
+  podAnnotations:
+    proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  terminationGracePeriodSeconds: 30
+  command:
+    - java
+  args:
+    - -server
+    - -Dspring.config.location=classpath:/application-fwbase.yml,/opt/config/application.yml
+    - org.springframework.boot.loader.launch.JarLauncher
+    - --jasypt.encryptor.password=changeme
+  ports: []
+  env:
+    - name: TZ
+      value: Asia/Ho_Chi_Minh
+    - name: SPRING_PROFILES_INCLUDE
+      value: fwbase
+  envFrom: []
+  volumeMounts: []
+  extraVolumeMounts: []
+  extraVolumes: []
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+service:
+  name: ""
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+configMap:
+  enabled: true
+  name: ""
+  mountPath: /opt/config
+  data:
+    application.yml: |-
+      server:
+        port: 8081
+      spring:
+        profiles:
+          active: uat
+        datasource:
+          url: ${SPRING_DATASOURCE_URL}
+          username: ${SPRING_DATASOURCE_USERNAME}
+          password: ${SPRING_DATASOURCE_PASSWORD}
+
+secrets:
+  enabled: false
+  name: ""
+  type: Opaque
+  autoMount: false
+  stringData: {}
+
+hpa:
+  enabled: true
+  apiVersion: autoscaling/v2
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: AverageValue
+          averageValue: "80"
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+    - type: External
+      external:
+        metric:
+          name: istio.io|service|server|request_count
+          selector:
+            matchLabels:
+              resource.type: k8s_container
+              metric.labels.destination_service_name: '{{ include "workload.appLabel" . }}'
+        target:
+          type: AverageValue
+          averageValue: "10"
+  behavior:
+    scaleDown:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 300
+    scaleUp:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 240
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+istio:
+  enabled: false
+  serviceHost: ""
+  hosts: []
+  gateways: []
+  contextPrefix: /
+  port: 8080
+  subsets:
+    - name: live
+      labels:
+        version: live
+    - name: pilot
+      labels:
+        version: pilot
+  routes:
+    - match:
+        - uri:
+            prefix: '{{ .Values.istio.contextPrefix }}'
+          headers:
+            version:
+              exact: pilot
+      route:
+        - destination:
+            host: '{{ include "workload.serviceName" . }}'
+            subset: pilot
+            port:
+              number: {{ .Values.istio.port }}
+    - match:
+        - uri:
+            prefix: '{{ .Values.istio.contextPrefix }}'
+      route:
+        - destination:
+            host: '{{ include "workload.serviceName" . }}'
+            subset: live
+            port:
+              number: {{ .Values.istio.port }}
+
+persistence:
+  enabled: false
+  volumeName: task-pv-volume
+  claimName: task-pv-claim
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  labels:
+    type: local
+  persistentVolume:
+    capacity: 5Gi
+    hostPath: /mnt/data
+    reclaimPolicy: Delete
+  persistentVolumeClaim:
+    requests:
+      storage: 3Gi


### PR DESCRIPTION
## Summary
- add a workload Helm chart covering the former Kustomize Deployment/StatefulSet, Service, HPA, Istio and persistence resources
- supply default and UAT overlay values plus helper templates for config maps, secrets and service accounts
- document chart usage and quick-start commands in the repository README

## Testing
- helm version *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d65ea899c083308c0d4c9c9bb9e773