### PR TITLE
Respect service account automount override

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -117,6 +117,8 @@ pdb: { enabled: true, minAvailable: 1 }
 # routingVersion: live     # nếu set -> labels.version = this; nếu không -> fallback image.tag
 ```
 
+*Có thể đặt `serviceAccount.automount=false` để không tự động mount ServiceAccount token vào Pod.*
+
 ### Cách chart đặt tên & nhãn (quan trọng)
 
 * **fullname** = `org-site-env-system-mainLabel` *(bỏ phần trống)*

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -182,3 +182,14 @@ app: {{ include "workload.appLabel" . }}
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* =========================
+   ServiceAccount automount toggle (default=true, respect false)
+   ========================= */}}
+{{- define "workload.serviceAccountAutomount" -}}
+{{- if hasKey .Values.serviceAccount "automount" -}}
+{{ .Values.serviceAccount.automount }}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/templates/serviceaccount.yaml
+++ b/charts/templates/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ default true .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ include "workload.serviceAccountAutomount" . }}
 {{- end }}

--- a/charts/templates/workload.yaml
+++ b/charts/templates/workload.yaml
@@ -50,7 +50,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: {{ .Values.workload.terminationGracePeriodSeconds }}
       serviceAccountName: {{ include "workload.serviceAccountNameSafe" . }}
-      automountServiceAccountToken: {{ default true .Values.serviceAccount.automount }}
+      automountServiceAccountToken: {{ include "workload.serviceAccountAutomount" . }}
 
       {{- with .Values.workload.priorityClassName }}
       priorityClassName: {{ . }}


### PR DESCRIPTION
## Summary
- add a helper to centralize the ServiceAccount automount flag and preserve explicit false values
- use the shared helper in both the Pod template and generated ServiceAccount
- document how to disable ServiceAccount token automount in the chart README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d702541934833098d790e7e8d0a07a