### PR TITLE
Respect explicit service disable flags

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -278,4 +278,27 @@ kubectl describe deploy/<fullname> | grep -A2 "checksum/"
 * Đặt `Release.Name` rõ ràng (ví dụ `t24-api-live`, `t24-api-pilot`) để dễ tra cứu lịch sử & rollback.
 * Khi xài Jenkins/GitOps, nhớ **tag ảnh bất biến** (`1.2.3`, `sha`) — đừng xài `latest`.
 
+## 12) Kiểm tra nhanh Service toggles
+
+Một số lệnh `helm template` giúp xác nhận behaviour mới:
+
+```bash
+# Tắt Service chính, chỉ render workload (Deployment)
+helm template demo ./charts --set service.enabled=false
+
+# StatefulSet vẫn render Service thường khi headless bị tắt
+helm template demo ./charts \
+  --set workload.kind=StatefulSet \
+  --set service.headlessEnabled=false
+
+# Khi đồng thời tắt cả hai Service cho StatefulSet sẽ báo lỗi
+helm template demo ./charts \
+  --set workload.kind=StatefulSet \
+  --set service.enabled=false \
+  --set service.headlessEnabled=false
+```
+
+Lệnh cuối phải trả về lỗi `Invalid config: StatefulSet requires either service.headlessEnabled=true or service.enabled=true...` để
+chứng minh guard chống cấu hình sai đang hoạt động.
+
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -151,9 +151,21 @@ app: {{ include "workload.appLabel" . }}
 {{- default (printf "%s-headless" (include "workload.fullname" .)) .Values.service.headlessName -}}
 {{- end -}}
 
-{{/* Headless enabled only makes sense for StatefulSet; default=true */}}
+{{- define "workload.serviceEnabled" -}}
+{{- $enabled := true -}}
+{{- if and (hasKey .Values "service") (hasKey .Values.service "enabled") -}}
+  {{- $enabled = .Values.service.enabled -}}
+{{- end -}}
+{{- if $enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
 {{- define "workload.headlessEnabled" -}}
-{{- if and (eq (include "workload.workloadKind" .) "StatefulSet") (ne (default true .Values.service.headlessEnabled) false) -}}true{{- else -}}false{{- end -}}
+{{- $isStateful := eq (include "workload.workloadKind" .) "StatefulSet" -}}
+{{- $enabled := and $isStateful true -}}
+{{- if and $isStateful (hasKey .Values "service") (hasKey .Values.service "headlessEnabled") -}}
+  {{- $enabled = .Values.service.headlessEnabled -}}
+{{- end -}}
+{{- if $enabled -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{/* Which serviceName should StatefulSet use? */}}

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -4,8 +4,10 @@ templates/service.yaml
 - Headless Service dành cho StatefulSet (bật qua service.headlessEnabled, default true cho STS)
 */ -}}
 {{- $kind := include "workload.workloadKind" . -}}
+{{- $serviceEnabled := eq (include "workload.serviceEnabled" .) "true" -}}
+{{- $headlessEnabled := eq (include "workload.headlessEnabled" .) "true" -}}
 
-{{- if default true .Values.service.enabled }}
+{{- if $serviceEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,7 +27,7 @@ spec:
 {{- end }}
 
 {{- /* Headless service cho StatefulSet: luôn dùng tên helper headlessServiceName */}}
-{{- if and (eq $kind "StatefulSet") (default true .Values.service.headlessEnabled) }}
+{{- if $headlessEnabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/templates/workload.yaml
+++ b/charts/templates/workload.yaml
@@ -6,9 +6,11 @@ templates/workload.yaml
 - Với StatefulSet, spec.serviceName dùng headless (nếu bật) qua helper workload.statefulServiceName
 */ -}}
 {{- $kind := include "workload.workloadKind" . -}}
+{{- $serviceEnabled := eq (include "workload.serviceEnabled" .) "true" -}}
+{{- $headlessEnabled := eq (include "workload.headlessEnabled" .) "true" -}}
 
 {{- /* Guard cấu hình xấu: STS mà tắt cả service chính & headless */ -}}
-{{- if and (eq $kind "StatefulSet") (not (default true .Values.service.headlessEnabled)) (not (default true .Values.service.enabled)) -}}
+{{- if and (eq $kind "StatefulSet") (not $headlessEnabled) (not $serviceEnabled) -}}
 {{- fail "Invalid config: StatefulSet requires either service.headlessEnabled=true or service.enabled=true to provide spec.serviceName." -}}
 {{- end -}}
 


### PR DESCRIPTION
## Summary
- ensure the Service and headless toggles honour explicit false values by using helper-based lookups
- reuse the shared helpers in workload guard logic so StatefulSet validation still fires when both toggles are off
- document manual helm template commands that verify the new behaviour

## Testing
- not run (helm CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7024fe4cc833093e65c0f7d6b975e