### PR TITLE
Document service toggles and persistence defaults

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -98,6 +98,7 @@ workload:
 service:
   enabled: true
   headlessEnabled: true     # dùng cho StatefulSet
+  headlessName: ""          # để trống -> auto <fullname>-headless
   name: ""                  # mặc định = fullname
   type: ClusterIP
   annotations: {}
@@ -112,6 +113,22 @@ secrets:   { enabled: true, name: "", autoMount: true, stringData: {} }
 serviceAccount: { create: true, name: "", annotations: {}, automount: true }
 hpa: { enabled: true, minReplicas: 1, maxReplicas: 3, metrics: [], behavior: {} }
 pdb: { enabled: true, minAvailable: 1 }
+
+# ===== PERSISTENCE =====
+persistence:
+  enabled: false
+  volumeName: ""
+  claimName: ""
+  storageClassName: ""
+  accessModes: []
+  labels: {}
+  persistentVolume:
+    reclaimPolicy: Delete
+    capacity: 5Gi
+    hostPath: ""
+  persistentVolumeClaim:
+    requests:
+      storage: 5Gi
 
 # (optional) nếu dùng Istio
 # routingVersion: live     # nếu set -> labels.version = this; nếu không -> fallback image.tag

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -77,6 +77,9 @@ workload:
   sidecars: []
 
 service:
+  enabled: true           # có thể tắt nếu không cần Service chính
+  headlessEnabled: true   # chỉ dùng cho StatefulSet; Deployment sẽ bỏ qua
+  headlessName: ""        # để trống -> auto fullname-headless
   name: ""                # để trống -> mặc định fullname
   type: ClusterIP
   annotations: {}
@@ -110,3 +113,18 @@ hpa:
 pdb:
   enabled: true
   minAvailable: 1
+
+persistence:
+  enabled: false
+  volumeName: ""
+  claimName: ""
+  storageClassName: ""
+  accessModes: []
+  labels: {}
+  persistentVolume:
+    reclaimPolicy: Delete
+    capacity: 5Gi
+    hostPath: ""
+  persistentVolumeClaim:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- expose the service enabled/headless toggles in `values.yaml` and document the headless name override
- add default persistence configuration values and document how to customize them

## Testing
- not run (Helm CLI unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68d737f2e244833081297082cc286dcd