### PR TITLE
Document service toggles and persistence defaults

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -98,6 +98,7 @@ workload:
 service:
   enabled: true
   headlessEnabled: true     # dùng cho StatefulSet
+  headlessName: ""          # để trống -> auto <fullname>-headless
   name: ""                  # mặc định = fullname
   type: ClusterIP
   annotations: {}
@@ -112,6 +113,24 @@ secrets:   { enabled: true, name: "", autoMount: true, stringData: {} }
 serviceAccount: { create: true, name: "", annotations: {}, automount: true }
 hpa: { enabled: true, minReplicas: 1, maxReplicas: 3, metrics: [], behavior: {} }
 pdb: { enabled: true, minAvailable: 1 }
+
+# ===== PERSISTENCE =====
+persistence:
+  enabled: false
+  volumeName: ""          # để trống -> auto <fullname>-pv
+  claimName: ""           # để trống -> auto <fullname>-pvc
+  storageClassName: ""
+  accessModes: [ReadWriteOnce]
+  labels: {}
+  persistentVolume:
+    reclaimPolicy: Delete
+    capacity: 5Gi
+    hostPath: ""
+  persistentVolumeClaim:
+    requests:
+      storage: 5Gi
+
+*Nếu `storageClassName` để trống chart sẽ bỏ qua field để dùng StorageClass mặc định của cluster.*
 
 # (optional) nếu dùng Istio
 # routingVersion: live     # nếu set -> labels.version = this; nếu không -> fallback image.tag

--- a/charts/templates/persistence.yaml
+++ b/charts/templates/persistence.yaml
@@ -1,19 +1,26 @@
 {{- if .Values.persistence.enabled }}
+{{- $fullName := include "workload.fullname" . -}}
+{{- $pvName := default (printf "%s-pv" $fullName) .Values.persistence.volumeName -}}
+{{- $pvcName := default (printf "%s-pvc" $fullName) .Values.persistence.claimName -}}
+{{- $accessModes := default (list "ReadWriteOnce") .Values.persistence.accessModes -}}
+{{- $storageClassName := .Values.persistence.storageClassName -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Values.persistence.volumeName }}
+  name: {{ $pvName }}
   {{- with .Values.persistence.labels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- if $storageClassName }}
+  storageClassName: {{ $storageClassName }}
+  {{- end }}
   persistentVolumeReclaimPolicy: {{ default "Delete" .Values.persistence.persistentVolume.reclaimPolicy }}
   capacity:
     storage: {{ .Values.persistence.persistentVolume.capacity }}
   accessModes:
-    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+    {{- toYaml $accessModes | nindent 4 }}
   {{- with .Values.persistence.persistentVolume.hostPath }}
   hostPath:
     path: {{ . | quote }}
@@ -22,11 +29,13 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.persistence.claimName }}
+  name: {{ $pvcName }}
 spec:
-  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- if $storageClassName }}
+  storageClassName: {{ $storageClassName }}
+  {{- end }}
   accessModes:
-    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+    {{- toYaml $accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.persistence.persistentVolumeClaim.requests.storage }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -77,6 +77,9 @@ workload:
   sidecars: []
 
 service:
+  enabled: true           # có thể tắt nếu không cần Service chính
+  headlessEnabled: true   # chỉ dùng cho StatefulSet; Deployment sẽ bỏ qua
+  headlessName: ""        # để trống -> auto fullname-headless
   name: ""                # để trống -> mặc định fullname
   type: ClusterIP
   annotations: {}
@@ -110,3 +113,18 @@ hpa:
 pdb:
   enabled: true
   minAvailable: 1
+
+persistence:
+  enabled: false
+  volumeName: ""          # để trống -> auto <fullname>-pv
+  claimName: ""           # để trống -> auto <fullname>-pvc
+  storageClassName: ""
+  accessModes: [ReadWriteOnce]
+  labels: {}
+  persistentVolume:
+    reclaimPolicy: Delete
+    capacity: 5Gi
+    hostPath: ""
+  persistentVolumeClaim:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary
- expose the service enabled/headless toggles in `values.yaml` and document the headless name override
- add default persistence configuration values and document how to customize them, including auto-generated volume/claim names and a sensible default access mode

## Testing
- not run (Helm CLI unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_e_68d737f2e244833081297082cc286dcd