### PR TITLE
Enforce persistence configuration validation

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -130,6 +130,10 @@ persistence:
     requests:
       storage: 5Gi
 
+# Khi bật persistence, các trường `volumeName`, `claimName` và `accessModes`
+# là bắt buộc. `storageClassName` có thể bỏ trống để dùng default StorageClass
+# (template sẽ tự bỏ qua field này khi rỗng).
+
 # (optional) nếu dùng Istio
 # routingVersion: live     # nếu set -> labels.version = this; nếu không -> fallback image.tag
 ```

--- a/charts/templates/persistence.yaml
+++ b/charts/templates/persistence.yaml
@@ -1,20 +1,28 @@
 {{- if .Values.persistence.enabled }}
+{{- $p := .Values.persistence -}}
+{{- $volumeName := required "persistence.volumeName is required when persistence.enabled=true" $p.volumeName -}}
+{{- $claimName := required "persistence.claimName is required when persistence.enabled=true" $p.claimName -}}
+{{- if not $p.accessModes }}
+  {{- fail "persistence.accessModes must not be empty when persistence.enabled=true" -}}
+{{- end -}}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Values.persistence.volumeName }}
-  {{- with .Values.persistence.labels }}
+  name: {{ $volumeName }}
+  {{- with $p.labels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  storageClassName: {{ .Values.persistence.storageClassName }}
-  persistentVolumeReclaimPolicy: {{ default "Delete" .Values.persistence.persistentVolume.reclaimPolicy }}
+  {{- with $p.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  persistentVolumeReclaimPolicy: {{ default "Delete" $p.persistentVolume.reclaimPolicy }}
   capacity:
-    storage: {{ .Values.persistence.persistentVolume.capacity }}
+    storage: {{ $p.persistentVolume.capacity }}
   accessModes:
-    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
-  {{- with .Values.persistence.persistentVolume.hostPath }}
+    {{- toYaml $p.accessModes | nindent 4 }}
+  {{- with $p.persistentVolume.hostPath }}
   hostPath:
     path: {{ . | quote }}
   {{- end }}
@@ -22,12 +30,14 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.persistence.claimName }}
+  name: {{ $claimName }}
 spec:
-  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- with $p.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
   accessModes:
-    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+    {{- toYaml $p.accessModes | nindent 4 }}
   resources:
     requests:
-      storage: {{ .Values.persistence.persistentVolumeClaim.requests.storage }}
+      storage: {{ $p.persistentVolumeClaim.requests.storage }}
 {{- end }}


### PR DESCRIPTION
## Summary
- guard against empty persistence identifiers when the feature is enabled and skip empty storageClassName values
- document the required persistence values so chart consumers know what to configure

## Testing
- not run (helm unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d73c0c2f0c8330a7c2e9bf0c10d638