### PR TITLE
Fix extra pod labels scope and honor secret automount

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -47,7 +47,7 @@ workload:
     type: RollingUpdate
     rollingUpdate: { maxSurge: 25%, maxUnavailable: 0 }
   terminationGracePeriodSeconds: 30
-  extraPodLabels: {}
+  extraPodLabels: {}      # chỉ áp dụng lên Pod template
   podAnnotations: {}
   nodeSelector: {}
   tolerations: []
@@ -107,7 +107,7 @@ service:
 
 # ===== CONFIGMAP / SECRET =====
 configMap: { enabled: true, name: "", data: {} }
-secrets:   { enabled: true, name: "", autoMount: true, stringData: {} }
+secrets:   { enabled: true, name: "", autoMount: true, stringData: {} }   # auto envFrom secretRef vào main container
 
 # ===== SA / HPA / PDB =====
 serviceAccount: { create: true, name: "", annotations: {}, automount: true }
@@ -139,6 +139,8 @@ persistence:
 ```
 
 *Có thể đặt `serviceAccount.automount=false` để không tự động mount ServiceAccount token vào Pod.*
+
+*Khi `secrets.autoMount=true`, chart sẽ tự thêm `envFrom.secretRef` trỏ đến Secret chính vào container `workload.main`.*
 
 ### Cách chart đặt tên & nhãn (quan trọng)
 

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -91,7 +91,12 @@ app.kubernetes.io/version: {{ include "workload.image.tag" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app: {{ include "workload.appLabel" . }}
 version: {{ include "workload.version" . }}
-{{- with .Values.workload.extraPodLabels }}{{ toYaml . }}{{- end }}
+{{- end -}}
+
+{{- define "workload.extraPodLabels" -}}
+{{- with .Values.workload.extraPodLabels }}
+{{ toYaml . }}
+{{- end -}}
 {{- end -}}
 
 {{/* =========================

--- a/charts/templates/workload.yaml
+++ b/charts/templates/workload.yaml
@@ -41,6 +41,10 @@ spec:
       labels:
         {{- include "workload.selectorLabels" . | nindent 8 }}
         {{- include "workload.labels" . | nindent 8 }}
+        {{- $extraPodLabels := include "workload.extraPodLabels" . -}}
+        {{- if $extraPodLabels }}
+        {{- $extraPodLabels | nindent 8 }}
+        {{- end }}
       annotations:
         {{- $cm := include "workload.configChecksum" . -}}
         {{- $sc := include "workload.secretChecksum" . -}}
@@ -143,9 +147,16 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
 
-          {{- with .Values.workload.main.envFrom }}
+          {{- $envFrom := list -}}
+          {{- with .Values.workload.main.envFrom -}}
+          {{- $envFrom = concat $envFrom . -}}
+          {{- end -}}
+          {{- if and .Values.secrets.enabled .Values.secrets.autoMount -}}
+          {{- $envFrom = append $envFrom (dict "secretRef" (dict "name" (include "workload.secretName" $))) -}}
+          {{- end -}}
+          {{- if $envFrom }}
           envFrom:
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml $envFrom | nindent 12 }}
           {{- end }}
 
           {{- with .Values.workload.main.resources }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -94,7 +94,7 @@ configMap:
 secrets:
   enabled: true
   name: ""
-  autoMount: true
+  autoMount: true       # tự động add envFrom Secret vào main container
   stringData: {}
 
 serviceAccount:


### PR DESCRIPTION
## Summary
- stop leaking `workload.extraPodLabels` onto non-pod resources by scoping them to the pod template only
- honor `secrets.autoMount` by appending the rendered secret to the main container envFrom list and document the behavior

## Testing
- not run (helm CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d73e03d61c8330b1203f6d6a5d3ac9