### PR TITLE
Separate StatefulSet update strategy values

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ workload:
   strategy:
     type: RollingUpdate
     rollingUpdate: { maxSurge: 25%, maxUnavailable: 0 }
+  statefulSetUpdateStrategy:
+    type: RollingUpdate
+    rollingUpdate: { partition: 0 }
   terminationGracePeriodSeconds: 30
   extraPodLabels: {}      # chỉ áp dụng lên Pod template
   podAnnotations: {}
@@ -196,6 +199,11 @@ helm upgrade --install t24-api ./charts \
 
 * `service.headlessEnabled: true` sẽ tạo thêm `headless Service` (`<fullname>-headless`) cho DNS ổn định.
 * Nếu app cần PVC per-pod, bổ sung `stateful.volumeClaimTemplates` trong values (phần optional bạn có thể thêm sau).
+
+### Chiến lược rollout
+
+* **Deployment** đọc cấu hình từ `workload.strategy` (Helm render vào `spec.strategy`).
+* **StatefulSet** chỉ hỗ trợ một số trường (`type`, `rollingUpdate.partition`), vì vậy chart dùng map riêng `workload.statefulSetUpdateStrategy` để render `spec.updateStrategy`.
 
 ---
 

--- a/charts/templates/workload.yaml
+++ b/charts/templates/workload.yaml
@@ -29,7 +29,7 @@ spec:
   {{- else }}
   serviceName: {{ include "workload.statefulServiceName" . }}
   updateStrategy:
-    {{- toYaml .Values.workload.strategy | nindent 4 }}
+    {{- toYaml .Values.workload.statefulSetUpdateStrategy | nindent 4 }}
   {{- end }}
 
   selector:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -19,6 +19,10 @@ workload:
   strategy:
     type: RollingUpdate
     rollingUpdate: { maxSurge: 25%, maxUnavailable: 0 }
+  statefulSetUpdateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
 
   terminationGracePeriodSeconds: 30
 


### PR DESCRIPTION
## Summary
- add a dedicated `workload.statefulSetUpdateStrategy` values block with defaults limited to supported fields
- render StatefulSet updateStrategy from the new values map while leaving Deployment strategy unchanged
- document the split strategy configuration in the README

## Testing
- helm template test charts *(fails: `helm` is not available in the execution environment)*
- helm template test charts --set workload.kind=StatefulSet *(fails: `helm` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7591459a88330926558df8b471903