### PR TITLE
Simplify persistence to PVC provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,22 +120,19 @@ pdb: { enabled: true, minAvailable: 1 }
 # ===== PERSISTENCE =====
 persistence:
   enabled: false
-  volumeName: ""
   claimName: ""
   storageClassName: ""
   accessModes: []
   labels: {}
-  persistentVolume:
-    reclaimPolicy: Delete
-    capacity: 5Gi
-    hostPath: ""
   persistentVolumeClaim:
     requests:
       storage: 5Gi
 
-# Khi bật persistence, các trường `volumeName`, `claimName` và `accessModes`
-# là bắt buộc. `storageClassName` có thể bỏ trống để dùng default StorageClass
-# (template sẽ tự bỏ qua field này khi rỗng).
+# Khi bật persistence, cần điền `claimName` và ít nhất một `accessMode`.
+# Chart chỉ tạo PVC và yêu cầu StorageClass động (hoặc StorageClass mặc định).
+# Có thể bỏ trống `storageClassName` để sử dụng StorageClass mặc định của cluster.
+
+*Chart không còn tạo PersistentVolume tĩnh; cluster cần có StorageClass hỗ trợ dynamic provisioning cho PVC.*
 
 # (optional) nếu dùng Istio
 # routingVersion: live     # nếu set -> labels.version = this; nếu không -> fallback image.tag

--- a/charts/templates/persistence.yaml
+++ b/charts/templates/persistence.yaml
@@ -1,36 +1,17 @@
 {{- if .Values.persistence.enabled }}
 {{- $p := .Values.persistence -}}
-{{- $volumeName := required "persistence.volumeName is required when persistence.enabled=true" $p.volumeName -}}
 {{- $claimName := required "persistence.claimName is required when persistence.enabled=true" $p.claimName -}}
 {{- if not $p.accessModes }}
   {{- fail "persistence.accessModes must not be empty when persistence.enabled=true" -}}
 {{- end -}}
 apiVersion: v1
-kind: PersistentVolume
+kind: PersistentVolumeClaim
 metadata:
-  name: {{ $volumeName }}
+  name: {{ $claimName }}
   {{- with $p.labels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-spec:
-  {{- with $p.storageClassName }}
-  storageClassName: {{ . }}
-  {{- end }}
-  persistentVolumeReclaimPolicy: {{ default "Delete" $p.persistentVolume.reclaimPolicy }}
-  capacity:
-    storage: {{ $p.persistentVolume.capacity }}
-  accessModes:
-    {{- toYaml $p.accessModes | nindent 4 }}
-  {{- with $p.persistentVolume.hostPath }}
-  hostPath:
-    path: {{ . | quote }}
-  {{- end }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ $claimName }}
 spec:
   {{- with $p.storageClassName }}
   storageClassName: {{ . }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -132,15 +132,10 @@ pdb:
 
 persistence:
   enabled: false
-  volumeName: ""
   claimName: ""
   storageClassName: ""
   accessModes: []
   labels: {}
-  persistentVolume:
-    reclaimPolicy: Delete
-    capacity: 5Gi
-    hostPath: ""
   persistentVolumeClaim:
     requests:
       storage: 5Gi


### PR DESCRIPTION
## Summary
- remove the statically provisioned PersistentVolume manifest from the persistence template
- update chart values and documentation to describe PVC-only dynamic provisioning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7626924e48330aa7877f80b31d193