### PR TITLE
Format checksum annotations in pod template

### DIFF
--- a/charts/templates/workload.yaml
+++ b/charts/templates/workload.yaml
@@ -48,8 +48,12 @@ spec:
       annotations:
         {{- $cm := include "workload.configChecksum" . -}}
         {{- $sc := include "workload.secretChecksum" . -}}
-        {{- if $cm }}checksum/config: {{ $cm }}{{- end }}
-        {{- if $sc }}checksum/secret: {{ $sc }}{{- end }}
+        {{- if $cm }}
+        checksum/config: {{ $cm }}
+        {{- end }}
+        {{- if $sc }}
+        checksum/secret: {{ $sc }}
+        {{- end }}
         {{- with .Values.workload.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Summary
- expand the checksum annotations in the pod template to multiline blocks so the keys stay aligned

## Testing
- helm template sb-t24-pilot ./charts -f values.yaml --set org=sb,env=pilot,system=t24,chartLabel=example-workload --debug *(fails: helm not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d76fe66d348330ac33bd14ab86ca85